### PR TITLE
Add alt text for site images

### DIFF
--- a/src/pages/About.at8ot.js
+++ b/src/pages/About.at8ot.js
@@ -2,9 +2,10 @@
 // “Hello, World!” Example: https://learn-code.wix.com/en/article/hello-world
 
 $w.onReady(function () {
-    // Write your JavaScript here
+    // Alt text for image showing members of the association
+    $w('#aboutImage').alt = 'Kokomo Art Association members in the gallery';
 
-    // To select an element by ID use: $w('#elementID')
-
-    // Click 'Preview' to run your code
+    // Decorative flourish
+    $w('#aboutDivider').alt = '';
 });
+

--- a/src/pages/Home.mainPage.js
+++ b/src/pages/Home.mainPage.js
@@ -2,9 +2,10 @@
 // “Hello, World!” Example: https://learn-code.wix.com/en/article/hello-world
 
 $w.onReady(function () {
-    // Write your JavaScript here
+    // Set alt text for meaningful images
+    $w('#heroImage').alt = 'Featured artwork from current exhibition';
 
-    // To select an element by ID use: $w('#elementID')
-
-    // Click 'Preview' to run your code
+    // Decorative images should have empty alt text so screen readers ignore them
+    $w('#decorativeDivider').alt = '';
 });
+

--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -2,9 +2,10 @@
 // “Hello, World!” Example: https://learn-code.wix.com/en/article/hello-world
 
 $w.onReady(function () {
-    // Write your JavaScript here
+    // Provide alt text for key site images
+    $w('#siteLogo').alt = 'Kokomo Art Association logo';
 
-    // To select an element by ID use: $w('#elementID')
-
-    // Click 'Preview' to run your code
+    // Decorative background image
+    $w('#backgroundTexture').alt = '';
 });
+


### PR DESCRIPTION
## Summary
- add descriptive alt text for primary images on home and about pages
- mark decorative images with empty alt attributes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5186ddd408328bc5903accdf67a1b