### PR TITLE
feat: improve alt text and SEO metadata

### DIFF
--- a/src/pages/About.at8ot.js
+++ b/src/pages/About.at8ot.js
@@ -1,5 +1,6 @@
 // API Reference: https://www.wix.com/velo/reference/api-overview/introduction
 // “Hello, World!” Example: https://learn-code.wix.com/en/article/hello-world
+import { seo } from 'wix-seo';
 
 $w.onReady(function () {
     // Alt text for image showing members of the association
@@ -7,5 +8,9 @@ $w.onReady(function () {
 
     // Decorative flourish
     $w('#aboutDivider').alt = '';
+
+    // SEO metadata
+    seo.setTitle('About Us | Kokomo Art Association');
+    seo.setDescription('Learn about the mission and history of the Kokomo Art Association.');
 });
 

--- a/src/pages/Events.hbshl.js
+++ b/src/pages/Events.hbshl.js
@@ -1,10 +1,16 @@
 // API Reference: https://www.wix.com/velo/reference/api-overview/introduction
 // “Hello, World!” Example: https://learn-code.wix.com/en/article/hello-world
+import { seo } from 'wix-seo';
 
 $w.onReady(function () {
-    // Write your JavaScript here
+    // Provide descriptive alt text for images on this page
+    $w('Image').forEach((img) => {
+        if (img.alt === 'Artwork or event image from the Kokomo Art Association') {
+            img.alt = 'Kokomo Art Association event photo';
+        }
+    });
 
-    // To select an element by ID use: $w('#elementID')
-
-    // Click 'Preview' to run your code
+    // Enhance SEO with page-specific metadata
+    seo.setTitle('Upcoming Art Events | Kokomo Art Association');
+    seo.setDescription('Browse art events, classes, and workshops hosted by the Kokomo Art Association.');
 });

--- a/src/pages/Home.mainPage.js
+++ b/src/pages/Home.mainPage.js
@@ -1,5 +1,6 @@
 // API Reference: https://www.wix.com/velo/reference/api-overview/introduction
 // “Hello, World!” Example: https://learn-code.wix.com/en/article/hello-world
+import { seo } from 'wix-seo';
 
 $w.onReady(function () {
     // Set alt text for meaningful images
@@ -7,5 +8,9 @@ $w.onReady(function () {
 
     // Decorative images should have empty alt text so screen readers ignore them
     $w('#decorativeDivider').alt = '';
+
+    // SEO metadata
+    seo.setTitle('Kokomo Art Association | Home');
+    seo.setDescription('Discover exhibitions, classes, and events offered by the Kokomo Art Association.');
 });
 

--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -1,11 +1,23 @@
 // API Reference: https://www.wix.com/velo/reference/api-overview/introduction
 // “Hello, World!” Example: https://learn-code.wix.com/en/article/hello-world
+import { seo } from 'wix-seo';
 
 $w.onReady(function () {
+    // Ensure all images have descriptive alt text
+    $w('Image').forEach((image) => {
+        if (typeof image.alt !== 'string' || image.alt.trim() === '') {
+            image.alt = 'Artwork or event image from the Kokomo Art Association';
+        }
+    });
+
     // Provide alt text for key site images
     $w('#siteLogo').alt = 'Kokomo Art Association logo';
 
     // Decorative background image
     $w('#backgroundTexture').alt = '';
+
+    // Default SEO meta tags
+    seo.setTitle('Kokomo Art Association');
+    seo.setDescription('Official site for the Kokomo Art Association featuring exhibitions, workshops, and community events.');
 });
 


### PR DESCRIPTION
## Summary
- add default alt text and SEO meta tags in master page
- set alt text and metadata for home, about, and events pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a536a3d14c8328bd11aade604dee9b